### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/0jonjo/calcpace/security/code-scanning/2](https://github.com/0jonjo/calcpace/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the provided steps, the workflow primarily involves checking out code, setting up Ruby, building a gem, and running tests. These tasks typically require only `contents: read` permissions. We will add this minimal permission to the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
