### PR TITLE
chore: update version to 1.8.2, enhance changelog, and update README …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.8.1] - 2026-03-06
+## [1.8.2] - 2026-03-07
 
 ### Added
+- GitHub Actions workflow for automated gem publishing to RubyGems.org on push to `main` when `lib/calcpace/version.rb` changes
+- Trusted publishing via OIDC (no API key required) using `rubygems/release-gem` action
+- Automatic GitHub Release creation with generated notes on each publish
+- `bundler/gem_tasks` added to `Rakefile` to support `rake release` and related tasks
 - SimpleCov integration for code coverage measurement
 - RuboCop lint job to CI pipeline
 - YARD documentation for all previously undocumented public methods in `Calculator` (`checked_velocity`, `clock_velocity`, `checked_pace`, `clock_pace`, `time`, `checked_time`, `clock_time`, `distance`, `checked_distance`)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    racc (1.8.2)
+    racc (1.8.1)
     rainbow (3.1.1)
     rake (13.3.1)
     rake-compiler (1.3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    racc (1.8.1)
+    racc (1.8.2)
     rainbow (3.1.1)
     rake (13.3.1)
     rake-compiler (1.3.1)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Calcpace [![Gem Version](https://d25lcipzij17d.cloudfront.net/badge.svg?id=rb&r=r&ts=1683906897&type=6e&v=1.8.1&x2=0)](https://badge.fury.io/rb/calcpace)
+# Calcpace [![Gem Version](https://d25lcipzij17d.cloudfront.net/badge.svg?id=rb&r=r&ts=1683906897&type=6e&v=1.8.2&x2=0)](https://badge.fury.io/rb/calcpace)
 
 Calcpace is a Ruby gem designed for calculations and conversions related to distance and time. It can calculate velocity, pace, total time, and distance, accepting time in various formats, including HH:MM:SS. The gem supports conversion to 42 different units, including kilometers, miles, meters, and feet. It also provides methods to validate input.
 
@@ -7,7 +7,7 @@ Calcpace is a Ruby gem designed for calculations and conversions related to dist
 ### Add to your Gemfile
 
 ```ruby
-gem 'calcpace', '~> 1.8.1'
+gem 'calcpace', '~> 1.8.2'
 ```
 
 Then run:

--- a/lib/calcpace/version.rb
+++ b/lib/calcpace/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Calcpace
-  VERSION = '1.8.1'
+  VERSION = '1.8.2'
 end


### PR DESCRIPTION
This pull request updates the project to version 1.8.2 and introduces automated publishing and release workflows. The most important changes are the addition of GitHub Actions for automated gem publishing and trusted release management, as well as updates to documentation and version references.

Automated publishing and release workflow:

* Added a GitHub Actions workflow for automated gem publishing to RubyGems.org on push to `main` when `lib/calcpace/version.rb` changes.
* Enabled trusted publishing using OIDC and the `rubygems/release-gem` action, removing the need for an API key.
* Automatic GitHub Release creation with generated notes on each publish.
* Added `bundler/gem_tasks` to `Rakefile` to support `rake release` and related tasks.

Documentation and version updates:

* Updated version references from 1.8.1 to 1.8.2 in `README.md` and `lib/calcpace/version.rb`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R10) [[3]](diffhunk://#diff-f0ce524d728573958247c79c10ed6cd81aba4b7ed5d3041db56cadcb43b92a8aL4-R4)
* Updated the changelog to reflect the new version and added workflow-related entries.…for gem version