### PR TITLE
chore: bump version to 1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.1] - 2026-03-30
+
+### Changed
+- Bump `json` from 2.19.0 to 2.19.2
+
 ## [1.9.0] - 2026-03-24
 
 ### Added

--- a/lib/calcpace/version.rb
+++ b/lib/calcpace/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Calcpace
-  VERSION = '1.9.0'
+  VERSION = '1.9.1'
 end


### PR DESCRIPTION
## Summary

- Bump version from 1.9.0 to 1.9.1
- Update CHANGELOG with `json` dependency bump (2.19.0 → 2.19.2)