### PR TITLE
feat: Vo2maxEstimator module v1.9.3 + README overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,395 +1,126 @@
 # Calcpace [![Gem Version](https://d25lcipzij17d.cloudfront.net/badge.svg?id=rb&r=r&ts=1683906897&type=6e&v=1.9.3&x2=0)](https://badge.fury.io/rb/calcpace)
 
-Calcpace is a Ruby gem for running and cycling calculations. It computes velocity, pace, total time, distance, and unit conversions (42 units). It also includes GPS track analysis (distance, elevation gain, per-km splits via the Haversine formula) and VO2max estimation from race results (Daniels & Gilbert formula).
+A Ruby gem for running and cycling calculations: pace, time, distance, unit conversions, race predictions, GPS track analysis, and VO2max estimation.
 
 ## Installation
-
-### Add to your Gemfile
 
 ```ruby
 gem 'calcpace', '~> 1.9'
 ```
 
-Then run:
-
-```bash
-bundle install
-```
-
-### Install the gem manually
-
-```bash
-gem install calcpace
-```
-
 ## Usage
-
-Before performing any calculations or conversions, create a new instance of Calcpace:
 
 ```ruby
 require 'calcpace'
-
-calculate = Calcpace.new
-```
-
-### Calculate using Integers or Floats
-
-Calcpace provides methods to calculate velocity, pace, total time, and distance. The methods are unit-agnostic, and the return value is a float. Here are some examples:
-
-```ruby
-calculate.velocity(3625, 12275) # => 3.386206896551724
-calculate.pace(3665, 12) # => 305.4166666666667
-calculate.time(210, 12) # => 2520.0
-calculate.distance(9660, 120) # => 80.5
-```
-
-Tip: Use the `round` method to round a float. For example:
-
-```ruby
-calculate.velocity(3625, 12275).round(3) # => 3.386
-```
-
-Remember:
-
-- Velocity is the distance divided by the time (e.g., m/s or km/h).
-- Pace is the time divided by the distance (e.g., minutes/km or minutes/miles).
-- Total time is the distance divided by the velocity.
-- Distance is the velocity multiplied by the time.
-
-### Calculate using Clocktime
-
-Calcpace also provides methods to calculate using clocktime (HH:MM:SS or MM:SS format string). The return value will be in seconds or clocktime, depending on the method called, except for `checked_distance`. Here are some examples:
-
-```ruby
-# The return will be in the unit you input/seconds or seconds/unit you input
-calculate.checked_velocity('01:00:00', 12275) # => 3.4097222222222223
-calculate.checked_pace('01:21:32', 10) # => 489.2
-calculate.checked_time('00:05:31', 12.6) # => 4170.599999999999
-
-calculate.checked_distance('01:21:32', '00:06:27') # => 12.640826873385013
-
-# The return will be in clocktime
-calculate.clock_pace('01:21:32', 10) # => "00:08:09"
-calculate.clock_velocity('01:00:00', 10317) # => "00:00:02"
-calculate.clock_time('00:05:31', 12.6) # => "01:09:30"
-```
-
-Note: Using the `clock` methods may be less precise than using other methods due to conversions.
-
-You can also use BigDecimal for more precise calculations. For example:
-
-```ruby
-require 'bigdecimal'
-calculate.checked_velocity('10:00:00', 10317).to_d # => #<BigDecimal:7f9f1b8b1d08,'0.2865833333 333333E1',27(36)>
-```
-
-To learn more about BigDecimal, check the [documentation](https://ruby-doc.org/stdlib-2.7.1/libdoc/bigdecimal/rdoc/BigDecimal.html).
-
-### Convert Distances and Velocities
-
-Use the `convert` method to convert a distance or velocity. The first parameter is the value to be converted, and the second parameter is the unit to which the value will be converted. The unit can be a string (e.g. 'km to meters') or a symbol (e.g. :km_to_meters). The gem supports 42 different units, including kilometers, miles, meters, knots, and feet.
-
-Here are some examples:
-
-```ruby
-converter.convert(10, :km_to_meters) # => 1000
-converter.convert(10, 'mi to km') # => 16.0934
-converter.convert(1, :nautical_mi_to_km) # => 1.852
-converter.convert(1, 'km h to m s') # => 0.277778
-converter.convert(1, :m_s_to_mi_h) # => 2.23694
-```
-
-| Conversion Unit      | Description                 |
-|----------------------|-----------------------------|
-| :km_to_mi            | Kilometers to Miles         |
-| :mi_to_km            | Miles to Kilometers         |
-| :nautical_mi_to_km   | Nautical Miles to Kilometers |
-| :km_to_nautical_mi   | Kilometers to Nautical Miles |
-| :meters_to_km        | Meters to Kilometers        |
-| :km_to_meters        | Kilometers to Meters        |
-| :meters_to_mi        | Meters to Miles             |
-| :mi_to_meters        | Miles to Meters             |
-| :m_s_to_km_h         | Meters per Second to Kilometers per Hour    |
-| :km_h_to_m_s         | Kilometers per Hour to Meters per Second    |
-| :m_s_to_mi_h         | Meters per Second to Miles per Hour    |
-| :mi_h_to_m_s         | Miles per Hour to Meters per Second    |
-| :m_s_to_feet_s       | Meters per Second to Feet per Second    |
-| :feet_s_to_m_s       | Feet per Second to Meters per Second    |
-| :km_h_to_mi_h        | Kilometers per Hour to Miles per Hour    |
-| :mi_h_to_km_h        | Miles per Hour to Kilometers per Hour    |
-
-You can list all the available units [here](/lib/calcpace/converter.rb), or using `list` methods. The return will be a hash with the unit and a description of the unit.
-
-```ruby
-converter.list_all
-# => {:km_to_mi=>"KM to MI", :mi_to_km=>"MI to KM", ...}
-
-converter.list_distance
-# => {:km_to_mi=>"KM to MI", :mi_to_km=>"MI to KM", ...}
-
-converter.list_speed
-# => {:m_s_to_km_h=>"M S to KM H", :km_h_to_m_s=>"KM H to M S", ...}
-```
-
-### Chain Conversions
-
-Perform multiple conversions in sequence with the converter chain feature:
-
-```ruby
 calc = Calcpace.new
-
-# Convert kilometers to miles to feet in one call
-calc.convert_chain(1, [:km_to_mi, :mi_to_feet])
-# => 3280.84 (1 km = 0.621 mi = 3280.84 feet)
-
-# Convert with description for debugging
-calc.convert_chain_with_description(100, [:meters_to_km, :km_to_mi])
-# => { result: 0.0621371, description: "100 → meters_to_km → km_to_mi → 0.0621" }
-
-# Speed conversions
-calc.convert_chain(10, [:m_s_to_km_h, :km_h_to_mi_h])
-# => 22.3694 (10 m/s = 36 km/h = 22.37 mi/h)
 ```
 
-### Race Pace Calculator
+---
 
-Calcpace includes a race pace calculator for standard race distances (5K, 10K, half-marathon, and marathon):
+### Basic Calculations
 
 ```ruby
-calc = Calcpace.new
+calc.velocity(3625, 12275)          # => 3.386  (distance / time)
+calc.pace(3665, 12)                 # => 305.4  (time / distance)
+calc.time(210, 12)                  # => 2520.0 (pace × distance)
+calc.distance(9660, 120)            # => 80.5   (velocity × time)
 
-# Calculate finish time for a race given a pace
-calc.race_time(300, '5k')              # => 1500.0 (5:00/km pace for 5K = 25:00)
-calc.race_time_clock('05:00', 'marathon') # => '03:30:58' (5:00/km pace for marathon)
-
-# Calculate required pace for a target finish time
-calc.race_pace('00:30:00', '5k')       # => 360.0 (need 6:00/km to finish 5K in 30:00)
-calc.race_pace_clock('04:00:00', 'marathon') # => '00:05:41' (need 5:41/km for 4-hour marathon)
-
-# List available race distances
-calc.list_races
-# => { '5k' => 5.0, '10k' => 10.0, 'half_marathon' => 21.0975, 'marathon' => 42.195 }
+# Clocktime input/output (HH:MM:SS or MM:SS)
+calc.clock_pace('01:00:00', 10)     # => "00:06:00"
+calc.clock_time('00:05:31', 12.6)   # => "01:09:30"
+calc.checked_distance('01:21:32', '00:06:27') # => 12.64
 ```
 
-Supported race distances:
-- `5k` - 5 kilometers
-- `10k` - 10 kilometers
-- `half_marathon` - 21.0975 kilometers
-- `marathon` - 42.195 kilometers
-- `1mile` - 1.60934 kilometers
-- `5mile` - 8.04672 kilometers
-- `10mile` - 16.0934 kilometers
+---
+
+### Unit Conversions
+
+30+ units supported. String or symbol format:
+
+```ruby
+calc.convert(10, :km_to_mi)         # => 6.21371
+calc.convert(10, 'mi to km')        # => 16.0934
+calc.convert(1, :m_s_to_km_h)       # => 3.6
+
+# Chain conversions
+calc.convert_chain(1, [:km_to_mi, :mi_to_feet])  # => 3280.84
+```
+
+See all units: `calc.list_all`, `calc.list_distance`, `calc.list_speed`.
+
+---
 
 ### Pace Conversions
 
-Convert running pace between kilometers and miles:
-
 ```ruby
-calc = Calcpace.new
-
-# Convert pace from km to miles
-calc.pace_km_to_mi('05:00')           # => '00:08:02' (5:00/km = 8:02/mi)
-calc.convert_pace('05:00', :km_to_mi) # => '00:08:02' (same as above)
-
-# Convert pace from miles to km
-calc.pace_mi_to_km('08:00')           # => '00:04:58' (8:00/mi ≈ 4:58/km)
-calc.convert_pace('08:00', :mi_to_km) # => '00:04:58' (same as above)
-
-# Works with numeric input (seconds) as well
-calc.pace_km_to_mi(300)               # => '00:08:02' (300 seconds/km)
-calc.pace_mi_to_km(480)               # => '00:04:58' (480 seconds/mi)
-
-# String format also supported
-calc.convert_pace('05:00', 'km to mi') # => '00:08:02'
+calc.pace_km_to_mi('05:00')   # => "00:08:02"
+calc.pace_mi_to_km('08:00')   # => "00:04:58"
 ```
 
-The pace conversions are particularly useful when:
-- Planning races in different countries (metric vs imperial)
-- Comparing training paces with international runners
-- Converting workout plans between pace formats
+---
+
+### Race Pace & Time
+
+```ruby
+calc.race_time_clock('05:00', 'marathon')          # => "03:30:58"
+calc.race_pace_clock('04:00:00', 'marathon')       # => "00:05:41"
+calc.list_races  # => { '5k' => 5.0, '10k' => 10.0, 'half_marathon' => 21.0975, ... }
+```
+
+---
 
 ### Race Splits
 
-Calculate split times for races to help pace your race strategy:
-
 ```ruby
-calc = Calcpace.new
-
-# Even pace splits for half marathon (every 5k)
+# Even pace — default
 calc.race_splits('half_marathon', target_time: '01:30:00', split_distance: '5k')
 # => ["00:21:20", "00:42:40", "01:03:59", "01:25:19", "01:30:00"]
 
-# Kilometer splits for 10K
-calc.race_splits('10k', target_time: '00:40:00', split_distance: '1k')
-# => ["00:04:00", "00:08:00", "00:12:00", ..., "00:40:00"]
-
-# Mile splits for marathon
-calc.race_splits('marathon', target_time: '03:30:00', split_distance: '1mile')
-# => ["00:08:02", "00:16:04", ..., "03:30:00"]
-
-# Negative splits strategy (second half faster)
+# Strategies: :even (default), :negative (second half faster), :positive (first half faster)
 calc.race_splits('10k', target_time: '00:40:00', split_distance: '5k', strategy: :negative)
-# => ["00:20:48", "00:40:00"] # First 5k slower, second 5k faster
-
-# Positive splits strategy (first half faster)
-calc.race_splits('10k', target_time: '00:40:00', split_distance: '5k', strategy: :positive)
-# => ["00:19:12", "00:40:00"] # First 5k faster, second 5k slower
+# => ["00:20:48", "00:40:00"]
 ```
 
-Supported strategies:
-- `:even` - Constant pace throughout (default)
-- `:negative` - Second half ~4% faster (progressive race)
-- `:positive` - First half ~4% faster (conservative start)
-
-Split distances can be:
-- Standard race distances: `'5k'`, `'10k'`, `'1mile'`, etc.
-- Custom distances: `2.5` (in kilometers), `'3k'`, etc.
+---
 
 ### Race Time Predictions
 
-Predict your race times at different distances based on a recent performance using the **Riegel formula**:
+**Riegel formula** (`T2 = T1 × (D2/D1)^1.06`):
 
 ```ruby
-calc = Calcpace.new
-
-# Predict marathon time from a 5K result
-calc.predict_time_clock('5k', '00:20:00', 'marathon')
-# => "03:11:49" (predicts 3:11:49 marathon from 20:00 5K)
-
-# Predict 10K time from half marathon
-calc.predict_time_clock('half_marathon', '01:30:00', '10k')
-# => "00:40:47"
-
-# Get predicted pace for target race
-calc.predict_pace_clock('5k', '00:20:00', 'marathon')
-# => "00:04:32" (4:32/km pace for predicted marathon)
-
-# Get complete equivalent performance info
+calc.predict_time_clock('5k', '00:20:00', 'marathon')   # => "03:11:49"
+calc.predict_pace_clock('5k', '00:20:00', 'marathon')   # => "00:04:32"
 calc.equivalent_performance('10k', '00:42:00', '5k')
-# => {
-#      time: 1209.0,
-#      time_clock: "00:20:09",
-#      pace: 241.8,
-#      pace_clock: "00:04:02"
-#    }
+# => { time: 1209.0, time_clock: "00:20:09", pace: 241.8, pace_clock: "00:04:02" }
 ```
 
-#### How the Riegel Formula Works
-
-The Riegel formula is a mathematical model that predicts race performance across different distances:
-
-**Formula:** `T2 = T1 × (D2/D1)^1.06`
-
-Where:
-- **T1** = your known time at distance D1
-- **T2** = predicted time at distance D2
-- **D1** = known race distance (in km)
-- **D2** = target race distance (in km)
-- **1.06** = fatigue/endurance factor
-
-**The 1.06 exponent** represents how pace slows as distance increases. If endurance was perfect (1.0), doubling distance would simply double time. But in reality, you slow down slightly - the 1.06 factor accounts for this accumulated fatigue.
-
-**Example:** From a 5K in 20:00, predict marathon time:
-- T1 = 1200 seconds (20:00)
-- D1 = 5 km
-- D2 = 42.195 km (marathon)
-- T2 = 1200 × (42.195/5)^1.06
-- T2 = 1200 × 9.591 = 11,509 seconds
-- T2 = **3:11:49**
-
-The formula works best for:
-- Distances from 5K to marathon
-- Recent race results (within 6-8 weeks)
-- Similar terrain and weather conditions
-- Well-trained runners with consistent pacing
-
-**Important notes:**
-- Predictions assume equal training and effort across distances
-- Results are estimates - actual performance varies by individual fitness, training focus, and race conditions
-- The formula is most accurate when predicting between similar distance ranges (e.g., 10K to half marathon)
-
-### Race Time Predictions — Cameron Formula
-
-An alternative predictor using the **Cameron formula**, which applies an exponential correction based on the known distance. Unlike Riegel's fixed power-law exponent, Cameron's correction is larger when predicting from shorter races (where anaerobic capacity plays a bigger role) and diminishes as the known distance increases.
+**Cameron formula** (exponential correction — tends to be more conservative from short distances):
 
 ```ruby
-calc = Calcpace.new
-
-# Predict marathon time from 10K
-calc.predict_time_cameron_clock('10k', '00:42:00', 'marathon')
-# => "02:57:46"
-
-# Predict 10K from 5K
-calc.predict_time_cameron_clock('5k', '00:20:00', '10k')
-# => "00:42:24"
-
-# Get predicted pace per km
-calc.predict_pace_cameron_clock('10k', '00:42:00', 'marathon')
-# => "00:04:13"
-
-# Raw seconds (useful for further calculations)
-calc.predict_time_cameron('5k', '00:20:00', 'half_marathon')
-# => 5382.7 (approximately 1:29:42)
+calc.predict_time_cameron_clock('10k', '00:42:00', 'marathon')  # => "02:57:46"
+calc.predict_pace_cameron_clock('10k', '00:42:00', 'marathon')  # => "00:04:13"
 ```
 
-#### How the Cameron Formula Works
-
-**Formula:** `T2 = T1 × (D2/D1) × [(a + b × e^(-D1/c)) / (a + b × e^(-D2/c))]`
-
-Where:
-- **T1** = known time, **D1** = known distance (km)
-- **T2** = predicted time, **D2** = target distance (km)
-- **a = 0.000495**, **b = 0.000985**, **c = 1.4485** (empirical constants)
-
-The exponential correction factor `f(d) = a + b × e^(-d/c)` decreases as distance grows. When predicting from a short race to a long one, `f(D1) > f(D2)`, making `T2` grow slightly faster than a pure linear extrapolation — accounting for the greater fatigue at longer distances.
-
-**Compared to Riegel:**
-- Predicting from short distances (5K): Cameron tends to be more conservative (slower prediction) — acknowledges that 5K speed has a larger anaerobic component
-- Predicting from moderate distances (10K): Cameron tends to be slightly more optimistic — 10K is already a strong predictor of marathon aerobic capacity
-- Both formulas are estimates; real performance depends on training specificity, conditions, and individual physiology
+---
 
 ### GPS Track Analysis
 
-Analyse a GPS track from an array of points (hashes with `:lat`, `:lon`, and optionally `:ele` in metres and `:time` as a `Time` object):
+Accepts an array of hashes with `:lat`, `:lon`, and optionally `:ele` (metres) and `:time` (`Time`):
 
 ```ruby
-calc = Calcpace.new
-
 points = [
   { lat: -23.5505, lon: -46.6333, ele: 760.0, time: Time.parse('2024-01-01 07:00:00') },
   { lat: -23.5510, lon: -46.6400, ele: 765.0, time: Time.parse('2024-01-01 07:05:00') },
   { lat: -23.5520, lon: -46.6480, ele: 758.0, time: Time.parse('2024-01-01 07:10:00') },
 ]
 
-# Distance between two coordinates (Haversine formula, returns km)
-calc.haversine_distance(-23.5505, -46.6333, -23.5510, -46.6340)
-# => 0.089
-
-# Total track distance in km
-calc.track_distance(points)
-# => 0.87
-
-# Elevation gain and loss in metres
-calc.elevation_gain(points)
-# => { gain: 5.0, loss: 7.0 }
-
-# Per-km splits (requires :time in each point)
-calc.track_splits(points, 1.0)
-# => [{ km: 1, elapsed: 312, pace: "05:12" }, ...]
+calc.haversine_distance(-23.5505, -46.6333, -23.5510, -46.6340)  # => 0.089 km
+calc.track_distance(points)    # => 0.87 km
+calc.elevation_gain(points)    # => { gain: 5.0, loss: 7.0 }
+calc.track_splits(points, 1.0) # => [{ km: 1, elapsed: 312, pace: "05:12" }, ...]
 ```
 
-#### How the Haversine Formula Works
-
-The Haversine formula calculates the great-circle distance between two points on a sphere using their latitude and longitude. It assumes the Earth is a perfect sphere with a radius of 6,371 km.
-
-**Formula:**
-```
-a = sin²(Δlat/2) + cos(lat1) × cos(lat2) × sin²(Δlon/2)
-c = 2 × atan2(√a, √(1−a))
-d = R × c
-```
-
-**Accuracy:** within ~0.3% of the WGS84 ellipsoid model used by GPS devices — sufficient for running and cycling distances. For geodetic surveying, use a library with ellipsoid support.
+**Haversine formula** — great-circle distance on a sphere (R = 6,371 km). Accuracy: ~0.3% of GPS/WGS84. Best for running and cycling distances; not for geodetic surveying.
 
 ---
 
@@ -398,23 +129,12 @@ d = R × c
 Estimate aerobic fitness from a race result using the **Daniels & Gilbert formula** (1979):
 
 ```ruby
-calc = Calcpace.new
-
-# Estimate VO2max from distance (km) and finish time
-calc.estimate_vo2max(10.0, '00:40:00')  # => 51.9
+calc.estimate_vo2max(10.0, '00:40:00')   # => 51.9 ml/kg/min
 calc.estimate_vo2max(42.195, '03:30:00') # => 44.8
-calc.estimate_vo2max(5.0, '20:00')       # => 49.8
+calc.estimate_vo2max(5.0, 2400)          # also accepts total seconds
 
-# Time can also be provided as total seconds
-calc.estimate_vo2max(10.0, 2400)         # => 51.9
-
-# Get a descriptive label for a VO2max value
 calc.vo2max_label(51.9)  # => "Very Good"
-calc.vo2max_label(65.0)  # => "Excellent"
-calc.vo2max_label(25.0)  # => "Beginner"
 ```
-
-#### VO2max Levels
 
 | VO2max (ml/kg/min) | Level     |
 |--------------------|-----------|
@@ -425,72 +145,49 @@ calc.vo2max_label(25.0)  # => "Beginner"
 | 30–39              | Fair      |
 | < 30               | Beginner  |
 
-#### How the Daniels & Gilbert Formula Works
-
-The formula relates running velocity and exercise duration to the oxygen demand as a percentage of VO2max:
-
+**Formula:**
 ```
-velocity (m/min)  = distance_m / time_min
-VO2               = −4.60 + 0.182258·v + 0.000104·v²
-%VO2max           = 0.8 + 0.1894393·e^(−0.012778·t) + 0.2989558·e^(−0.1932605·t)
-VO2max            = VO2 / %VO2max
+velocity (m/min) = distance_m / time_min
+VO2              = −4.60 + 0.182258·v + 0.000104·v²
+%VO2max          = 0.8 + 0.1894393·e^(−0.012778·t) + 0.2989558·e^(−0.1932605·t)
+VO2max           = VO2 / %VO2max
 ```
 
-**Accuracy:** ±3–5 ml/kg/min vs. laboratory testing. Best results with efforts between **5 and 60 minutes** at a near-maximal (race) pace. Accuracy decreases for very short (< 5 min) or very long (> 4 h) efforts.
+Accuracy: ±3–5 ml/kg/min vs. laboratory testing. Best with efforts between **5 and 60 minutes** at near-maximal pace.
 
 ---
 
-### Other Useful Methods
-
-Calcpace also provides other useful methods:
+### Other Utilities
 
 ```ruby
-converter = Calcpace.new
-converter.convert_to_seconds('01:00:00') # => 3600
-converter.convert_to_clocktime(3600) # => '01:00:00'
-converter.convert_to_clocktime(100000) # => '1 03:46:40'
-converter.check_time('01:00:00') # => nil
+calc.convert_to_seconds('01:00:00')  # => 3600
+calc.convert_to_clocktime(3600)      # => "01:00:00"
+calc.check_time('01:00:00')          # => nil (valid)
 ```
+
+---
 
 ### Errors
 
-The gem now raises specific custom error classes for invalid inputs, allowing for more precise error handling. These errors inherit from `Calcpace::Error`.
+All errors inherit from `Calcpace::Error`:
 
-- `Calcpace::NonPositiveInputError`: Raised when a numeric input is not positive.
-- `Calcpace::InvalidTimeFormatError`: Raised when a time string is not in the expected `HH:MM:SS` or `MM:SS` format.
+- `Calcpace::NonPositiveInputError` — numeric input is zero or negative
+- `Calcpace::InvalidTimeFormatError` — time string not in `HH:MM:SS` or `MM:SS` format
 
-For example:
-
-```ruby
-begin
-  calculate.pace(945, -1)
-rescue Calcpace::NonPositiveInputError => e
-  puts e.message # => "Distance must be a positive number"
-end
-
-begin
-  calculate.checked_time('string', 10)
-rescue Calcpace::InvalidTimeFormatError => e
-  puts e.message # => "It must be a valid time in the XX:XX:XX or XX:XX format"
-end
-```
+---
 
 ### Testing
-
-To run the tests, clone the repository and run:
 
 ```bash
 bundle exec rake
 ```
 
-### Supported Ruby Versions
-
-The tests are run using Ruby versions from 2.7.8 to 3.4.2, as specified in the `.github/workflows/test.yml` file.
+Requires Ruby >= 3.2.0.
 
 ## Contributing
 
-We welcome contributions to Calcpace! To contribute, clone this repository and submit a pull request. Please ensure that your code adheres to our style and includes tests where appropriate.
+Clone the repo and submit a pull request. Please include tests.
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+[MIT License](https://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Calcpace [![Gem Version](https://d25lcipzij17d.cloudfront.net/badge.svg?id=rb&r=r&ts=1683906897&type=6e&v=1.9.0&x2=0)](https://badge.fury.io/rb/calcpace)
+# Calcpace [![Gem Version](https://d25lcipzij17d.cloudfront.net/badge.svg?id=rb&r=r&ts=1683906897&type=6e&v=1.9.3&x2=0)](https://badge.fury.io/rb/calcpace)
 
-Calcpace is a Ruby gem designed for calculations and conversions related to distance and time. It can calculate velocity, pace, total time, and distance, accepting time in various formats, including HH:MM:SS. The gem supports conversion to 42 different units, including kilometers, miles, meters, and feet. It also provides methods to validate input.
+Calcpace is a Ruby gem for running and cycling calculations. It computes velocity, pace, total time, distance, and unit conversions (42 units). It also includes GPS track analysis (distance, elevation gain, per-km splits via the Haversine formula) and VO2max estimation from race results (Daniels & Gilbert formula).
 
 ## Installation
 
@@ -347,6 +347,98 @@ The exponential correction factor `f(d) = a + b × e^(-d/c)` decreases as distan
 - Predicting from short distances (5K): Cameron tends to be more conservative (slower prediction) — acknowledges that 5K speed has a larger anaerobic component
 - Predicting from moderate distances (10K): Cameron tends to be slightly more optimistic — 10K is already a strong predictor of marathon aerobic capacity
 - Both formulas are estimates; real performance depends on training specificity, conditions, and individual physiology
+
+### GPS Track Analysis
+
+Analyse a GPS track from an array of points (hashes with `:lat`, `:lon`, and optionally `:ele` in metres and `:time` as a `Time` object):
+
+```ruby
+calc = Calcpace.new
+
+points = [
+  { lat: -23.5505, lon: -46.6333, ele: 760.0, time: Time.parse('2024-01-01 07:00:00') },
+  { lat: -23.5510, lon: -46.6400, ele: 765.0, time: Time.parse('2024-01-01 07:05:00') },
+  { lat: -23.5520, lon: -46.6480, ele: 758.0, time: Time.parse('2024-01-01 07:10:00') },
+]
+
+# Distance between two coordinates (Haversine formula, returns km)
+calc.haversine_distance(-23.5505, -46.6333, -23.5510, -46.6340)
+# => 0.089
+
+# Total track distance in km
+calc.track_distance(points)
+# => 0.87
+
+# Elevation gain and loss in metres
+calc.elevation_gain(points)
+# => { gain: 5.0, loss: 7.0 }
+
+# Per-km splits (requires :time in each point)
+calc.track_splits(points, 1.0)
+# => [{ km: 1, elapsed: 312, pace: "05:12" }, ...]
+```
+
+#### How the Haversine Formula Works
+
+The Haversine formula calculates the great-circle distance between two points on a sphere using their latitude and longitude. It assumes the Earth is a perfect sphere with a radius of 6,371 km.
+
+**Formula:**
+```
+a = sin²(Δlat/2) + cos(lat1) × cos(lat2) × sin²(Δlon/2)
+c = 2 × atan2(√a, √(1−a))
+d = R × c
+```
+
+**Accuracy:** within ~0.3% of the WGS84 ellipsoid model used by GPS devices — sufficient for running and cycling distances. For geodetic surveying, use a library with ellipsoid support.
+
+---
+
+### VO2max Estimation
+
+Estimate aerobic fitness from a race result using the **Daniels & Gilbert formula** (1979):
+
+```ruby
+calc = Calcpace.new
+
+# Estimate VO2max from distance (km) and finish time
+calc.estimate_vo2max(10.0, '00:40:00')  # => 51.9
+calc.estimate_vo2max(42.195, '03:30:00') # => 44.8
+calc.estimate_vo2max(5.0, '20:00')       # => 49.8
+
+# Time can also be provided as total seconds
+calc.estimate_vo2max(10.0, 2400)         # => 51.9
+
+# Get a descriptive label for a VO2max value
+calc.vo2max_label(51.9)  # => "Very Good"
+calc.vo2max_label(65.0)  # => "Excellent"
+calc.vo2max_label(25.0)  # => "Beginner"
+```
+
+#### VO2max Levels
+
+| VO2max (ml/kg/min) | Level     |
+|--------------------|-----------|
+| ≥ 70               | Elite     |
+| 60–69              | Excellent |
+| 50–59              | Very Good |
+| 40–49              | Good      |
+| 30–39              | Fair      |
+| < 30               | Beginner  |
+
+#### How the Daniels & Gilbert Formula Works
+
+The formula relates running velocity and exercise duration to the oxygen demand as a percentage of VO2max:
+
+```
+velocity (m/min)  = distance_m / time_min
+VO2               = −4.60 + 0.182258·v + 0.000104·v²
+%VO2max           = 0.8 + 0.1894393·e^(−0.012778·t) + 0.2989558·e^(−0.1932605·t)
+VO2max            = VO2 / %VO2max
+```
+
+**Accuracy:** ±3–5 ml/kg/min vs. laboratory testing. Best results with efforts between **5 and 60 minutes** at a near-maximal (race) pace. Accuracy decreases for very short (< 5 min) or very long (> 4 h) efforts.
+
+---
 
 ### Other Useful Methods
 

--- a/calcpace.gemspec
+++ b/calcpace.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ['João Gilberto Saraiva']
   spec.email         = ['joaogilberto@tuta.io']
 
-  spec.summary       = 'A Ruby gem for pace, distance, and time calculations.'
-  spec.description   = 'Ruby gem for pace, distance, time, and speed calculations. Supports multiple units and formats.'
+  spec.summary       = 'Pace, distance, GPS track analysis, and VO2max calculations for runners and cyclists.'
+  spec.description   = 'Ruby gem for running and cycling calculations: pace, time, distance, unit conversions (30+ units), race predictions (Riegel & Cameron), GPS track analysis (Haversine, elevation gain, per-km splits), and VO2max estimation (Daniels & Gilbert).'
   spec.homepage      = 'https://github.com/0jonjo/calcpace'
   spec.metadata['source_code_uri'] = spec.homepage
   spec.license = 'MIT'

--- a/calcpace.gemspec
+++ b/calcpace.gemspec
@@ -9,7 +9,10 @@ Gem::Specification.new do |spec|
   spec.email         = ['joaogilberto@tuta.io']
 
   spec.summary       = 'Pace, distance, GPS track analysis, and VO2max calculations for runners and cyclists.'
-  spec.description   = 'Ruby gem for running and cycling calculations: pace, time, distance, unit conversions (30+ units), race predictions (Riegel & Cameron), GPS track analysis (Haversine, elevation gain, per-km splits), and VO2max estimation (Daniels & Gilbert).'
+  spec.description   = 'Ruby gem for running and cycling calculations: pace, time, distance, ' \
+                       'unit conversions (30+ units), race predictions (Riegel & Cameron), ' \
+                       'GPS track analysis (Haversine, elevation gain, per-km splits), ' \
+                       'and VO2max estimation (Daniels & Gilbert).'
   spec.homepage      = 'https://github.com/0jonjo/calcpace'
   spec.metadata['source_code_uri'] = spec.homepage
   spec.license = 'MIT'

--- a/lib/calcpace.rb
+++ b/lib/calcpace.rb
@@ -11,6 +11,7 @@ require_relative 'calcpace/pace_converter'
 require_relative 'calcpace/race_predictor'
 require_relative 'calcpace/race_splits'
 require_relative 'calcpace/track_calculator'
+require_relative 'calcpace/vo2max_estimator'
 
 # Calcpace - A Ruby gem for pace, distance, and time calculations
 #
@@ -44,6 +45,7 @@ class Calcpace
   include RacePredictor
   include RaceSplits
   include TrackCalculator
+  include Vo2maxEstimator
 
   # Creates a new Calcpace instance
   #

--- a/lib/calcpace/version.rb
+++ b/lib/calcpace/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Calcpace
-  VERSION = '1.9.2'
+  VERSION = '1.9.3'
 end

--- a/lib/calcpace/vo2max_estimator.rb
+++ b/lib/calcpace/vo2max_estimator.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# Module for estimating VO2max from a race performance
+#
+# Uses the Daniels & Gilbert formula (1979), which relates running velocity
+# and exercise duration to oxygen consumption as a percentage of VO2max.
+#
+# Formula:
+#   velocity (m/min)  = distance_m / time_min
+#   VO2               = -4.60 + 0.182258 * v + 0.000104 * v²
+#   %VO2max           = 0.8 + 0.1894393·e^(-0.012778·t) + 0.2989558·e^(-0.1932605·t)
+#   VO2max            = VO2 / %VO2max
+#
+# Accuracy: ±3–5 ml/kg/min vs laboratory testing. Best results with efforts
+# between 5 and 60 minutes at race pace (i.e. near-maximal effort).
+module Vo2maxEstimator
+  VO2MAX_LABELS = [
+    { min: 70, label: 'Elite' },
+    { min: 60, label: 'Excellent' },
+    { min: 50, label: 'Very Good' },
+    { min: 40, label: 'Good' },
+    { min: 30, label: 'Fair' },
+    { min: 0,  label: 'Beginner' }
+  ].freeze
+
+  # Estimates VO2max from a race performance using Daniels & Gilbert formula
+  #
+  # @param distance_km [Numeric] race distance in kilometres (must be > 0)
+  # @param time [String, Integer] finish time as "HH:MM:SS" / "MM:SS", or total seconds (must be > 0)
+  # @return [Float] estimated VO2max in ml/kg/min, rounded to one decimal place
+  # @raise [ArgumentError] if distance or time are not positive
+  #
+  # @example 10 km in 40:00 → ~51.9 ml/kg/min
+  #   calc = Calcpace.new
+  #   calc.estimate_vo2max(10.0, '00:40:00') #=> 51.9
+  def estimate_vo2max(distance_km, time)
+    distance_m = distance_km.to_f * 1000
+    time_min   = parse_time_minutes(time)
+
+    check_positive(distance_m, 'Distance')
+    check_positive(time_min,   'Time')
+
+    velocity    = distance_m / time_min
+    vo2         = vo2_at_velocity(velocity)
+    pct_vo2max  = percent_vo2max(time_min)
+
+    (vo2 / pct_vo2max).round(1)
+  end
+
+  # Returns a descriptive label for a given VO2max value
+  #
+  # @param value [Numeric] VO2max in ml/kg/min
+  # @return [String] label: "Beginner", "Fair", "Good", "Very Good", "Excellent", or "Elite"
+  # @raise [ArgumentError] if value is not positive
+  #
+  # @example
+  #   calc.vo2max_label(51.9) #=> "Very Good"
+  def vo2max_label(value)
+    check_positive(value.to_f, 'VO2max value')
+
+    VO2MAX_LABELS.find { |entry| value.to_f >= entry[:min] }[:label]
+  end
+
+  private
+
+  def vo2_at_velocity(velocity)
+    -4.60 + (0.182258 * velocity) + (0.000104 * (velocity**2))
+  end
+
+  def percent_vo2max(time_min)
+    0.8 +
+      (0.1894393 * Math.exp(-0.012778 * time_min)) +
+      (0.2989558 * Math.exp(-0.1932605 * time_min))
+  end
+
+  def parse_time_minutes(time)
+    return time.to_f / 60.0 if time.is_a?(Numeric)
+
+    parts = time.to_s.split(':').map(&:to_f)
+    parse_parts(parts, time)
+  end
+
+  def parse_parts(parts, original)
+    case parts.size
+    when 3 then ((parts[0] * 3600) + (parts[1] * 60) + parts[2]) / 60.0
+    when 2 then ((parts[0] * 60) + parts[1]) / 60.0
+    else raise ArgumentError, "Invalid time format: #{original}. Use HH:MM:SS or MM:SS."
+    end
+  end
+end

--- a/lib/calcpace/vo2max_estimator.rb
+++ b/lib/calcpace/vo2max_estimator.rb
@@ -28,7 +28,8 @@ module Vo2maxEstimator
   # @param distance_km [Numeric] race distance in kilometres (must be > 0)
   # @param time [String, Integer] finish time as "HH:MM:SS" / "MM:SS", or total seconds (must be > 0)
   # @return [Float] estimated VO2max in ml/kg/min, rounded to one decimal place
-  # @raise [ArgumentError] if distance or time are not positive
+  # @raise [Calcpace::NonPositiveInputError] if distance or time are not positive
+  # @raise [Calcpace::InvalidTimeFormatError] if time string is not in HH:MM:SS or MM:SS format
   #
   # @example 10 km in 40:00 → ~51.9 ml/kg/min
   #   calc = Calcpace.new
@@ -76,15 +77,7 @@ module Vo2maxEstimator
   def parse_time_minutes(time)
     return time.to_f / 60.0 if time.is_a?(Numeric)
 
-    parts = time.to_s.split(':').map(&:to_f)
-    parse_parts(parts, time)
-  end
-
-  def parse_parts(parts, original)
-    case parts.size
-    when 3 then ((parts[0] * 3600) + (parts[1] * 60) + parts[2]) / 60.0
-    when 2 then ((parts[0] * 60) + parts[1]) / 60.0
-    else raise ArgumentError, "Invalid time format: #{original}. Use HH:MM:SS or MM:SS."
-    end
+    check_time(time.to_s)
+    convert_to_seconds(time.to_s) / 60.0
   end
 end

--- a/test/calcpace/test_vo2max_estimator.rb
+++ b/test/calcpace/test_vo2max_estimator.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Tests for Vo2maxEstimator module — Daniels & Gilbert formula
+class TestVo2maxEstimator < CalcpaceTest
+  # --- estimate_vo2max ---
+
+  def test_10k_in_40min_returns_expected_value
+    result = @calc.estimate_vo2max(10.0, '00:40:00')
+    assert_in_delta 51.9, result, 0.5
+  end
+
+  def test_5k_in_20min_returns_plausible_value
+    result = @calc.estimate_vo2max(5.0, '00:20:00')
+    assert_in_delta 49.8, result, 0.5
+  end
+
+  def test_marathon_in_3h30_returns_plausible_value
+    result = @calc.estimate_vo2max(42.195, '03:30:00')
+    assert_in_delta 45.0, result, 2.0
+  end
+
+  def test_accepts_mm_ss_format
+    result = @calc.estimate_vo2max(5.0, '20:00')
+    assert_kind_of Float, result
+    assert result.positive?
+  end
+
+  def test_accepts_time_in_seconds
+    result_str = @calc.estimate_vo2max(10.0, '00:40:00')
+    result_int = @calc.estimate_vo2max(10.0, 2400)
+    assert_in_delta result_str, result_int, 0.1
+  end
+
+  def test_returns_float_rounded_to_one_decimal
+    result = @calc.estimate_vo2max(10.0, '00:40:00')
+    assert_instance_of Float, result
+    assert_equal result, result.round(1)
+  end
+
+  def test_raises_for_zero_distance
+    assert_raises(Calcpace::NonPositiveInputError) { @calc.estimate_vo2max(0, '00:40:00') }
+  end
+
+  def test_raises_for_zero_time
+    assert_raises(Calcpace::NonPositiveInputError) { @calc.estimate_vo2max(10.0, 0) }
+  end
+
+  def test_raises_for_invalid_time_format
+    assert_raises(ArgumentError) { @calc.estimate_vo2max(10.0, 'fast') }
+  end
+
+  # --- vo2max_label ---
+
+  def test_label_elite
+    assert_equal 'Elite', @calc.vo2max_label(72.0)
+  end
+
+  def test_label_excellent
+    assert_equal 'Excellent', @calc.vo2max_label(65.0)
+  end
+
+  def test_label_very_good
+    assert_equal 'Very Good', @calc.vo2max_label(52.0)
+  end
+
+  def test_label_good
+    assert_equal 'Good', @calc.vo2max_label(45.0)
+  end
+
+  def test_label_fair
+    assert_equal 'Fair', @calc.vo2max_label(35.0)
+  end
+
+  def test_label_beginner
+    assert_equal 'Beginner', @calc.vo2max_label(25.0)
+  end
+
+  def test_label_raises_for_non_positive_value
+    assert_raises(Calcpace::NonPositiveInputError) { @calc.vo2max_label(0) }
+    assert_raises(Calcpace::NonPositiveInputError) { @calc.vo2max_label(-5) }
+  end
+
+  def test_estimate_and_label_integrate_for_10k_in_40min
+    vo2max = @calc.estimate_vo2max(10.0, '00:40:00')
+    assert_equal 'Very Good', @calc.vo2max_label(vo2max)
+  end
+end

--- a/test/calcpace/test_vo2max_estimator.rb
+++ b/test/calcpace/test_vo2max_estimator.rb
@@ -48,7 +48,11 @@ class TestVo2maxEstimator < CalcpaceTest
   end
 
   def test_raises_for_invalid_time_format
-    assert_raises(ArgumentError) { @calc.estimate_vo2max(10.0, 'fast') }
+    assert_raises(Calcpace::InvalidTimeFormatError) { @calc.estimate_vo2max(10.0, 'fast') }
+  end
+
+  def test_raises_for_non_numeric_time_segments
+    assert_raises(Calcpace::InvalidTimeFormatError) { @calc.estimate_vo2max(10.0, '00:aa:00') }
   end
 
   # --- vo2max_label ---


### PR DESCRIPTION
## Summary

- Add `Vo2maxEstimator` module (`lib/calcpace/vo2max_estimator.rb`) with two public methods:
  - `estimate_vo2max(distance_km, time)` — Daniels & Gilbert (1979) formula, accepts HH:MM:SS, MM:SS, or seconds
  - `vo2max_label(value)` — returns descriptive string: Beginner / Fair / Good / Very Good / Excellent / Elite
- 18 tests covering formula accuracy, time formats, edge cases, and error handling
- Update `calcpace.rb` and `version.rb` to 1.9.3
- Condense README from 496 to ~193 lines — all modules documented, GPS and VO2max sections added
- Update gemspec summary and description to reflect current scope

## API convention confirmed
Inputs use symbols (`:even`, `:km_to_mi`); all text outputs are strings (`"Very Good"`, `"00:05:00"`).