### PR TITLE
feat: Add support for 100K race distance (v1.9.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.4] - 2026-04-18
+
+### Added
+- Standard race distance support for **100K** (100.0 km)
+  - Supported in `PaceCalculator`, `RacePredictor`, `CameronPredictor`, and `RaceSplits`
+  - Updated `list_races` to include 100K
+  - Added test coverage for 100K race list inclusion
+
 ## [1.9.1] - 2026-03-30
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Standard race distance support for **100K** (100.0 km)
   - Supported in `PaceCalculator`, `RacePredictor`, `CameronPredictor`, and `RaceSplits`
   - Updated `list_races` to include 100K
-  - Added test coverage for 100K race list inclusion
+  - Added integration tests for 100K race distance across all modules
+
+## [1.9.3] - 2026-04-05
+
+### Added
+- VO2max Estimator module (`Vo2maxEstimator`)
+  - Daniels & Gilbert (1979) formula for VO2max estimation from race results
+  - Performance level labels (Elite, Excellent, etc.)
+- Improved time validation using strict `check_time` and `convert_to_seconds`
+- Updated YARD documentation for all calculation methods
+
+### Fixed
+- Gemspec formatting and line length constraints
+- README structure and documentation examples
+
+## [1.9.2] - 2026-03-31
+
+### Added
+- Track Calculator module (`TrackCalculator`)
+  - Haversine distance calculation for GPS coordinates
+  - Elevation gain and loss analysis
+  - Automated track splits based on GPS points
 
 ## [1.9.1] - 2026-03-30
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ calc.pace_mi_to_km('08:00')   # => "00:04:58"
 ```ruby
 calc.race_time_clock('05:00', 'marathon')          # => "03:30:58"
 calc.race_pace_clock('04:00:00', 'marathon')       # => "00:05:41"
-calc.list_races  # => { '5k' => 5.0, '10k' => 10.0, 'half_marathon' => 21.0975, ... }
+calc.list_races  # => { '5k' => 5.0, '10k' => 10.0, 'half_marathon' => 21.0975, 'marathon' => 42.195, '100k' => 100.0, ... }
 ```
 
 ---

--- a/lib/calcpace/cameron_predictor.rb
+++ b/lib/calcpace/cameron_predictor.rb
@@ -24,7 +24,7 @@ module CameronPredictor
 
   # Predicts race time using the Cameron formula
   #
-  # @param from_race [String, Symbol] known race distance ('5k', '10k', 'half_marathon', 'marathon', etc.)
+  # @param from_race [String, Symbol] known race distance ('5k', '10k', 'half_marathon', 'marathon', '100k', etc.)
   # @param from_time [String, Numeric] time achieved at known distance (HH:MM:SS or seconds)
   # @param to_race [String, Symbol] target race distance to predict
   # @return [Float] predicted time in seconds

--- a/lib/calcpace/pace_calculator.rb
+++ b/lib/calcpace/pace_calculator.rb
@@ -3,7 +3,7 @@
 # Module for calculating race times and paces for standard distances
 #
 # This module provides convenience methods for calculating finish times
-# and paces for common race distances like 5K, 10K, half-marathon, and marathon.
+# and paces for common race distances like 5K, 10K, half-marathon, marathon, and 100K.
 module PaceCalculator
   # Standard race distances in kilometers
   RACE_DISTANCES = {
@@ -11,6 +11,7 @@ module PaceCalculator
     '10k' => 10.0,
     'half_marathon' => 21.0975,
     'marathon' => 42.195,
+    '100k' => 100.0,
     '1mile' => 1.60934,
     '5mile' => 8.04672,
     '10mile' => 16.0934
@@ -19,7 +20,7 @@ module PaceCalculator
   # Calculates the finish time for a race given a pace per kilometer
   #
   # @param pace_per_km [Numeric, String] pace in seconds per km or time string (MM:SS)
-  # @param race [String, Symbol] race distance ('5k', '10k', 'half_marathon', 'marathon')
+  # @param race [String, Symbol] race distance ('5k', '10k', 'half_marathon', 'marathon', '100k')
   # @return [Float] total time in seconds
   # @raise [ArgumentError] if race distance is not recognized
   #
@@ -36,7 +37,7 @@ module PaceCalculator
   # Calculates the finish time for a race and returns it as a clock time string
   #
   # @param pace_per_km [Numeric, String] pace in seconds per km or time string (MM:SS)
-  # @param race [String, Symbol] race distance ('5k', '10k', 'half_marathon', 'marathon')
+  # @param race [String, Symbol] race distance ('5k', '10k', 'half_marathon', 'marathon', '100k')
   # @return [String] finish time in HH:MM:SS format
   #
   # @example
@@ -49,7 +50,7 @@ module PaceCalculator
   # Calculates the required pace per kilometer to finish a race in a target time
   #
   # @param target_time [Numeric, String] target finish time in seconds or time string (HH:MM:SS)
-  # @param race [String, Symbol] race distance ('5k', '10k', 'half_marathon', 'marathon')
+  # @param race [String, Symbol] race distance ('5k', '10k', 'half_marathon', 'marathon', '100k')
   # @return [Float] required pace in seconds per kilometer
   #
   # @example
@@ -65,7 +66,7 @@ module PaceCalculator
   # Calculates the required pace and returns it as a clock time string
   #
   # @param target_time [Numeric, String] target finish time in seconds or time string (HH:MM:SS)
-  # @param race [String, Symbol] race distance ('5k', '10k', 'half_marathon', 'marathon')
+  # @param race [String, Symbol] race distance ('5k', '10k', 'half_marathon', 'marathon', '100k')
   # @return [String] required pace in MM:SS format
   #
   # @example

--- a/lib/calcpace/race_predictor.rb
+++ b/lib/calcpace/race_predictor.rb
@@ -19,7 +19,7 @@ module RacePredictor
   # - D2 = target distance
   # - 1.06 = endurance/fatigue factor (longer races require proportionally more time)
   #
-  # @param from_race [String, Symbol] known race distance ('5k', '10k', 'half_marathon', 'marathon', etc.)
+  # @param from_race [String, Symbol] known race distance ('5k', '10k', 'half_marathon', 'marathon', '100k', etc.)
   # @param from_time [String, Numeric] time achieved at known distance (HH:MM:SS or seconds)
   # @param to_race [String, Symbol] target race distance to predict
   # @return [Float] predicted time in seconds

--- a/lib/calcpace/race_splits.rb
+++ b/lib/calcpace/race_splits.rb
@@ -7,7 +7,7 @@
 module RaceSplits
   # Calculates split times for a race
   #
-  # @param race [String, Symbol] race distance ('5k', '10k', 'half_marathon', 'marathon', etc.)
+  # @param race [String, Symbol] race distance ('5k', '10k', 'half_marathon', 'marathon', '100k', etc.)
   # @param target_time [String] target finish time in HH:MM:SS or MM:SS format
   # @param split_distance [String, Numeric] distance for each split ('5k', '1k', '1mile', or numeric in km)
   # @param strategy [Symbol] pacing strategy - :even (default), :negative, or :positive
@@ -42,7 +42,7 @@ module RaceSplits
     if split_distance.is_a?(Numeric)
       split_distance.to_f
     elsif split_distance.is_a?(String)
-      # Try to get from RACE_DISTANCES first (includes standard distances like '5k', '1mile', etc.)
+      # Try to get from RACE_DISTANCES first (includes standard distances like '5k', '100k', '1mile', etc.)
       distance_key = split_distance.to_s.downcase
 
       # Check if it's a standard race distance

--- a/lib/calcpace/version.rb
+++ b/lib/calcpace/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Calcpace
-  VERSION = '1.9.3'
+  VERSION = '1.9.4'
 end

--- a/test/calcpace/test_pace_calculator.rb
+++ b/test/calcpace/test_pace_calculator.rb
@@ -42,6 +42,12 @@ class TestPaceCalculator < CalcpaceTest
     assert_in_delta 6329.25, result, 0.5
   end
 
+  def test_race_time_100k
+    # 6:00/km pace for 100k (360s/km) should be 10 hours (36000 seconds)
+    result = @calc.race_time(360, '100k')
+    assert_equal 36_000.0, result
+  end
+
   def test_race_time_clock_format
     # 5:00/km pace for 5K should return "00:25:00"
     result = @calc.race_time_clock(300, '5k')
@@ -70,6 +76,12 @@ class TestPaceCalculator < CalcpaceTest
     # To run marathon in 3:30:00 (12600 seconds), need ~4:57/km
     result = @calc.race_pace('03:30:00', 'marathon')
     assert_in_delta 298.61, result, 1.0
+  end
+
+  def test_race_pace_100k
+    # To run 100k in 10:00:00 (36000 seconds), need 6:00/km (360s/km)
+    result = @calc.race_pace('10:00:00', '100k')
+    assert_equal 360.0, result
   end
 
   def test_race_pace_clock_format

--- a/test/calcpace/test_pace_calculator.rb
+++ b/test/calcpace/test_pace_calculator.rb
@@ -7,11 +7,12 @@ class TestPaceCalculator < CalcpaceTest
   def test_list_races
     races = @calc.list_races
     assert_kind_of Hash, races
-    assert_equal 7, races.size
+    assert_equal 8, races.size
     assert_equal 5.0, races['5k']
     assert_equal 10.0, races['10k']
     assert_equal 21.0975, races['half_marathon']
     assert_equal 42.195, races['marathon']
+    assert_equal 100.0, races['100k']
     assert_equal 1.60934, races['1mile']
     assert_equal 8.04672, races['5mile']
     assert_equal 16.0934, races['10mile']

--- a/test/calcpace/test_race_predictor.rb
+++ b/test/calcpace/test_race_predictor.rb
@@ -215,4 +215,11 @@ class TestRacePredictor < CalcpaceTest
     # Should be very close to original (allowing small rounding differences)
     assert_in_delta time_5k, back_to_5k, 5
   end
+
+  def test_predict_100k_from_marathon
+    # Marathon in 3:00:00 (10800s) should predict roughly 7:30 for 100K
+    # 10800 * (100/42.195)^1.06 ≈ 27021s
+    result = @calc.predict_time('marathon', '03:00:00', '100k')
+    assert_in_delta 27021, result, 100
+  end
 end

--- a/test/calcpace/test_race_predictor.rb
+++ b/test/calcpace/test_race_predictor.rb
@@ -220,6 +220,6 @@ class TestRacePredictor < CalcpaceTest
     # Marathon in 3:00:00 (10800s) should predict roughly 7:30 for 100K
     # 10800 * (100/42.195)^1.06 ≈ 27021s
     result = @calc.predict_time('marathon', '03:00:00', '100k')
-    assert_in_delta 27021, result, 100
+    assert_in_delta 27_021, result, 100
   end
 end

--- a/test/calcpace/test_race_splits.rb
+++ b/test/calcpace/test_race_splits.rb
@@ -205,4 +205,13 @@ class TestRaceSplits < CalcpaceTest
       assert_equal target, result[-1], "Final split should match target for #{strategy} strategy"
     end
   end
+
+  def test_race_splits_100k_10k
+    # 100K in 10:00:00 with 10k splits
+    result = @calc.race_splits('100k', target_time: '10:00:00', split_distance: '10k')
+
+    assert_equal 10, result.length
+    assert_equal '01:00:00', result[0] # First 10k should be 1 hour
+    assert_equal '10:00:00', result[9] # Finish
+  end
 end


### PR DESCRIPTION
This PR adds standard support for the 100K race distance across all modules.

### Changes:
- Added '100k' => 100.0 to standard race distances.
- Updated `PaceCalculator`, `RacePredictor`, `CameronPredictor`, and `RaceSplits` to support the new distance.
- Updated documentation in `README.md` and code comments.
- Added test coverage for the new distance in the race list.
- Bumped version to 1.9.4.