### PR TITLE
refactor: extract dig_key helper in TrackCalculator (v1.9.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.10] - 2026-07-09
+
+### Changed
+- Refactor `TrackCalculator`: extract a single `dig_key` helper for symbol/string key access, removing duplicated fallback logic across coordinate, elevation, and time readers (no behavior change)
+
 ## [1.9.9] - 2026-06-17
 
 ### Changed

--- a/lib/calcpace/track_calculator.rb
+++ b/lib/calcpace/track_calculator.rb
@@ -190,7 +190,7 @@ module TrackCalculator
 
   def validate_points_have_time(points)
     points.each_with_index do |pt, i|
-      next if pt[:time] || pt['time']
+      next if dig_key(pt, :time)
 
       raise ArgumentError, "Point at index #{i} is missing :time key required for splits"
     end

--- a/lib/calcpace/track_calculator.rb
+++ b/lib/calcpace/track_calculator.rb
@@ -74,8 +74,8 @@ module TrackCalculator
     return 0.0 if points.nil? || points.size < 2
 
     total = points.each_cons(2).sum do |a, b|
-      haversine_distance(fetch_coord(a, :lat), fetch_coord(a, :lon),
-                         fetch_coord(b, :lat), fetch_coord(b, :lon))
+      haversine_distance(dig_key(a, :lat), dig_key(a, :lon),
+                         dig_key(b, :lat), dig_key(b, :lon))
     end
 
     total.round(2)
@@ -180,13 +180,12 @@ module TrackCalculator
     end
   end
 
-  def fetch_coord(point, key)
+  def dig_key(point, key)
     point[key] || point[key.to_s]
   end
 
   def fetch_ele(point)
-    val = point[:ele] || point['ele']
-    val&.to_f
+    dig_key(point, :ele)&.to_f
   end
 
   def validate_points_have_time(points)
@@ -198,7 +197,7 @@ module TrackCalculator
   end
 
   def point_time(point)
-    t = point[:time] || point['time']
+    t = dig_key(point, :time)
     t.respond_to?(:to_f) ? t.to_f : t
   end
 
@@ -228,8 +227,8 @@ module TrackCalculator
   end
 
   def process_segment(point_a, point_b, split_km, state)
-    segment_km = haversine_distance(fetch_coord(point_a, :lat), fetch_coord(point_a, :lon),
-                                    fetch_coord(point_b, :lat), fetch_coord(point_b, :lon))
+    segment_km = haversine_distance(dig_key(point_a, :lat), dig_key(point_a, :lon),
+                                    dig_key(point_b, :lat), dig_key(point_b, :lon))
     state[:accumulated_km] += segment_km
 
     while state[:accumulated_km] >= split_km * state[:split_number]

--- a/lib/calcpace/version.rb
+++ b/lib/calcpace/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Calcpace
-  VERSION = '1.9.9'
+  VERSION = '1.9.10'
 end


### PR DESCRIPTION
## What

Collapses the duplicated symbol/string key-access pattern (`point[key] || point[key.to_s]`) in `TrackCalculator` into a single private `dig_key` helper.

- `fetch_ele` and `point_time` now delegate to `dig_key`
- The redundant `fetch_coord` wrapper is inlined at its 4 call sites and removed
- Symbol/string fallback logic now lives in one place

## Why

DRY. Changing how points are keyed (e.g. normalizing input) becomes a one-line edit instead of touching three readers.

## Version

Patch bump **1.9.9 → 1.9.10** — internal refactor, no public API change. CHANGELOG updated.

## Verification

- `test_track_calculator.rb`: 29 runs, 0 failures
- Full suite: 259 runs, 0 failures
- Rubocop: clean (35 files)